### PR TITLE
Update dependencies and automation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,3 +15,8 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
+  - package-ecosystem: "docker-compose"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,9 +10,8 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@v6.0.2
+      - uses: actions/setup-go@v6.4.0
         with:
-          go-version: '1.25'
-      - uses: golangci/golangci-lint-action@v9
-
+          go-version: '1.26.3'
+      - uses: golangci/golangci-lint-action@v9.2.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ jobs:
   docker-release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6.0.2
       - name: Docker login
         run: docker login --username ${{ secrets.DOCKER_LOGIN }} --password ${{ secrets.DOCKER_PASSWORD }}
       - name: Docker release
@@ -18,13 +18,13 @@ jobs:
   github-release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6.0.2
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@v6.4.0
         with:
-          go-version: '1.25'
+          go-version: '1.26.3'
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v7
+        uses: goreleaser/goreleaser-action@v7.2.2
         with:
           version: latest
           args: release --clean

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,3 +1,5 @@
+version: 2
+
 builds:
   - env:
       - CGO_ENABLED=0
@@ -8,7 +10,7 @@ builds:
 checksum:
   name_template: 'checksums.txt'
 snapshot:
-  name_template: "{{ .Tag }}"
+  version_template: "{{ .Tag }}"
 changelog:
   sort: asc
   filters:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26-alpine3.22 as builder
+FROM golang:1.26.3-alpine3.23 as builder
 
 WORKDIR /go/src/github.com/mxssl/ntwrk
 COPY . .

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ export GO111MODULE=on
 all: lint build
 
 build:
-	go build -v -mod=vendor -o ${BINARY_NAME}
+	go build -v -o ${BINARY_NAME}
 
 clean:
 	rm -f ${BINARY_NAME}
@@ -25,11 +25,11 @@ deps-update:
 
 github-release-dry:
 	@echo "TAG: ${TAG}"
-	goreleaser release --rm-dist --snapshot --skip-publish
+	goreleaser release --clean --snapshot
 
 github-release:
 	@echo "TAG: ${TAG}"
-	goreleaser release --rm-dist
+	goreleaser release --clean
 
 docker-release:
 	@echo "Registry: ${DOCKER_REGISTRY}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
   ntwrk:
     build:

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/mxssl/ntwrk
 
-go 1.25
+go 1.26
+
+toolchain go1.26.3
 
 require github.com/joho/godotenv v1.5.1


### PR DESCRIPTION
## Summary
- moves the module to Go 1.26 with toolchain go1.26.3
- pins current stable GitHub Actions tags for checkout, setup-go, golangci-lint-action, and goreleaser-action
- updates the Docker builder image to golang:1.26.3-alpine3.23 while keeping the runtime on alpine:3.23.4
- removes the obsolete Docker Compose top-level version key and adds Dependabot coverage for Docker Compose
- migrates GoReleaser config to the default .goreleaser.yaml filename and v2 config format
- refreshes Makefile release/build commands for current GoReleaser and module-based builds

## Validation
- go get -u ./...
- go mod tidy
- go test ./...
- golangci-lint run
- goreleaser check
- docker compose config
- docker manifest inspect golang:1.26.3-alpine3.23
- docker manifest inspect alpine:3.23.4
- make build
